### PR TITLE
Fix issues with projects having URI-unsafe glyphs

### DIFF
--- a/src/lib/gerrit/gerritAPI/api.ts
+++ b/src/lib/gerrit/gerritAPI/api.ts
@@ -921,7 +921,7 @@ export class GerritAPI {
 
 		const response = await this._tryRequest(
 			this.getURL(
-				`projects/${project}/commits/${
+				`projects/${encodeURIComponent(project)}/commits/${
 					commit.id
 				}/files/${encodeURIComponent(filePath)}/content`
 			),


### PR DESCRIPTION
My project was named something like "xxxxx/xxx" and the extension tried to fetch some subpaths that Gerrit couldn't find