### PR TITLE
Use fsPath for matching the gitRepo

### DIFF
--- a/src/lib/gerrit/gerrit.ts
+++ b/src/lib/gerrit/gerrit.ts
@@ -105,7 +105,7 @@ export async function isUsingGerrit(silent: boolean = false): Promise<boolean> {
 	} else {
 		const config = getConfiguration().get('gerrit.gitRepo');
 		const match = gerritRepos.find(
-			(repo) => repo.rootUri.toString() === config
+			(repo) => repo.rootUri.fsPath === config
 		);
 		if (match) {
 			gerritRepo = match;


### PR DESCRIPTION
Since `repo.rootUri` is a URI and `gerrit.gitRepo` is a path, they never match.

`"file:///home/user/repo"` != `"/home/user/repo"`

Fixes #48