### PR TITLE
Fix #54 - Support newer gerrit (3.9.x) version using a different id format

### DIFF
--- a/src/lib/git/git.ts
+++ b/src/lib/git/git.ts
@@ -300,8 +300,8 @@ export function getChangeIDFromCheckoutString(
 	if (changeID.indexOf('~') === 0) {
 		return changeID;
 	}
-	const [, , id] = changeID.split('~');
-	return id;
+	const [, idFromPair, idFromTriplet] = changeID.split('~');
+	return idFromTriplet ?? idFromPair;
 }
 
 export async function gitCheckoutRemote(


### PR DESCRIPTION
Fix for #54